### PR TITLE
Langchain | Adjust openai requirements

### DIFF
--- a/intelligent_debtor/requirements.txt
+++ b/intelligent_debtor/requirements.txt
@@ -140,10 +140,7 @@ keras==2.15.0
 Keras-Preprocessing==1.1.2
 kiwisolver==1.4.4
 kthread==0.2.3
-langchain==0.1.5
-langchain-community==0.0.19
-langchain-core==0.1.21
-langsmith==0.0.87
+
 lazy-object-proxy==1.9.0
 lazy_loader==0.3
 libclang==16.0.0
@@ -259,7 +256,7 @@ SQLAlchemy==2.0.25
 stack-data==0.6.2
 starlette==0.27.0
 statsmodels==0.14.0
-streamlit==1.29.0
+
 taipy==3.0.0
 taipy-config==3.0.0
 taipy-core==3.0.0

--- a/text_adventure/llm_playground/llm_app.py
+++ b/text_adventure/llm_playground/llm_app.py
@@ -1,14 +1,20 @@
 import streamlit as st
-from langchain_community.llms import openai
+import os
+from dotenv import load_dotenv
+from langchain_openai import OpenAI
+
+load_dotenv()
 
 st.title(':rainbow[_Basic LLM_]')
 
 with st.sidebar:
-    openai_api_key = st.text_input('OpenAI API Key', type='password')
+    openai_api_key = st.text_input('OpenAI API Key', type='password', value=os.getenv("OPENAI_API_KEY"))
+
 
 def generate_response(input):
-    llm = openai(temperature=0.7, openai_api_key=openai_api_key)
+    llm = OpenAI(temperature=0.7, openai_api_key=openai_api_key)
     st.info(llm(input))
+
 
 with st.form('input_form', border=True):
     input = st.text_area('Your input:', 'Think of something to ask the LLM.')

--- a/text_adventure/requirements.txt
+++ b/text_adventure/requirements.txt
@@ -1,0 +1,8 @@
+langchain-community==0.0.19
+langchain-core==0.1.21
+langchain-openai==0.0.5
+langchain==0.1.5
+langsmith==0.0.87
+python-dotenv==1.0.1
+openai==1.11.1
+streamlit==1.29.0


### PR DESCRIPTION
# Changes 
- updated connection to llm
  - community llm required openai from pip to work
  - upon using, received deprecation notice and instructions to use updated package
 - moved project requirements into individual requirements
   - monorepo deps are tough, its a lot easier when requirements are isolated
   - i was getting conflicts and pip wouldnt install
 - pull open api key from env file

# Screenshots
![image](https://github.com/avirklol/projects_pub/assets/5975475/f26918e4-36fd-431c-9b8e-777ff5e1a1c3)

# Notes
Deprecation notice once community package worked
> LangChainDeprecationWarning: The class `langchain_community.llms.openai.OpenAI` was deprecated in langchain-community 0.0.10 and will be removed in 0.2.0. An updated version of the class exists in the langchain-openai package and should be used instead. To use it run `pip install -U langchain-openai` and import as `from langchain_openai import OpenAI`.

Deprecation and dependency notice from langchain
https://api.python.langchain.com/en/stable/llms/langchain_community.llms.openai.OpenAI.html
![image](https://github.com/avirklol/projects_pub/assets/5975475/72dde148-2ab2-4dee-b3d6-c81811d1932b)
